### PR TITLE
Pipe bivalent booster data through API

### DIFF
--- a/.github/workflows/CI_test_deploy_api.yml
+++ b/.github/workflows/CI_test_deploy_api.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
       with:
-        repository: covid-projections/covid-data-model
+        repository: act-now-coalition/covid-data-model
         path: covid-data-model
         ref: '${{env.COVID_DATA_MODEL_REF}}'
         lfs: true

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
       with:
-        repository: covid-projections/covid-data-model
+        repository: act-now-coalition/covid-data-model
         lfs: true
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -237,7 +237,7 @@ number of people vaccinated with both the first and second dose.
         None,
         description="Number of individuals who are fully vaccinated and have received a booster (or additional) dose.",
     )
-    vaccinationsBivalentDose: Optional[int] = pydantic.Field(
+    vaccinationsFall2022BivalentBooster: Optional[int] = pydantic.Field(
         None, description="Number of individuals who have received a bivalent vaccine dose.",
     )
     vaccinesAdministered: Optional[int] = pydantic.Field(
@@ -328,8 +328,8 @@ class Annotations(base_model.APIBaseModel):
     vaccinationsAdditionalDose: Optional[FieldAnnotations] = pydantic.Field(
         None, description="Annotations for vaccinationsAdditionalDose"
     )
-    vaccinationsBivalentDose: Optional[FieldAnnotations] = pydantic.Field(
-        None, description="Annotations for vaccinationsBivalentDose"
+    vaccinationsFall2022BivalentBooster: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for vaccinationsFall2022BivalentBooster"
     )
     vaccinesAdministered: Optional[FieldAnnotations] = pydantic.Field(
         None, description="Annotations for vaccinesAdministered"
@@ -371,8 +371,8 @@ class Annotations(base_model.APIBaseModel):
     vaccinationsAdditionalDoseRatio: Optional[FieldAnnotations] = pydantic.Field(
         None, description=("Annotations for vaccinationsAdditionalDoseRatio"),
     )
-    vaccinationsBivalentDoseRatio: Optional[FieldAnnotations] = pydantic.Field(
-        None, description="Annotations for vaccinationsBivalentDoseRatio."
+    vaccinationsFall2022BivalentBoosterRatio: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for vaccinationsFall2022BivalentBoosterRatio."
     )
 
 
@@ -437,7 +437,7 @@ class Metrics(base_model.APIBaseModel):
             "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
         ),
     )
-    vaccinationsBivalentDoseRatio: Optional[float] = pydantic.Field(
+    vaccinationsFall2022BivalentBoosterRatio: Optional[float] = pydantic.Field(
         None, description=("Ratio of population that have received a bivalent vaccine dose."),
     )
 

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -369,13 +369,10 @@ class Annotations(base_model.APIBaseModel):
         None, description="Annotations for vaccinationsCompletedRatio"
     )
     vaccinationsAdditionalDoseRatio: Optional[FieldAnnotations] = pydantic.Field(
-        None,
-        description=(
-            "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
-        ),
+        None, description=("Annotations for vaccinationsAdditionalDoseRatio"),
     )
     vaccinationsBivalentDoseRatio: Optional[FieldAnnotations] = pydantic.Field(
-        None, description="Ratio of population have received a bivalent vaccine dose."
+        None, description="Annotations for vaccinationsBivalentDoseRatio."
     )
 
 
@@ -420,12 +417,12 @@ class Metrics(base_model.APIBaseModel):
 
     bedsWithCovidPatientsRatio: Optional[float] = pydantic.Field(
         ...,
-        description="Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+        description="Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
     )
 
     weeklyCovidAdmissionsPer100k: Optional[float] = pydantic.Field(
         ...,
-        description="Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+        description="Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
     )
 
     vaccinationsInitiatedRatio: Optional[float] = pydantic.Field(
@@ -441,7 +438,7 @@ class Metrics(base_model.APIBaseModel):
         ),
     )
     vaccinationsBivalentDoseRatio: Optional[float] = pydantic.Field(
-        None, description=("Ratio of population have received a bivalent vaccine dose."),
+        None, description=("Ratio of population that have received a bivalent vaccine dose."),
     )
 
     @staticmethod

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -237,6 +237,9 @@ number of people vaccinated with both the first and second dose.
         None,
         description="Number of individuals who are fully vaccinated and have received a booster (or additional) dose.",
     )
+    vaccinationsBivalentDose: Optional[int] = pydantic.Field(
+        None, description="Number of individuals who have received a bivalent vaccine dose.",
+    )
     vaccinesAdministered: Optional[int] = pydantic.Field(
         None, description="Total number of vaccine doses administered."
     )
@@ -325,6 +328,9 @@ class Annotations(base_model.APIBaseModel):
     vaccinationsAdditionalDose: Optional[FieldAnnotations] = pydantic.Field(
         None, description="Annotations for vaccinationsAdditionalDose"
     )
+    vaccinationsBivalentDose: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for vaccinationsBivalentDose"
+    )
     vaccinesAdministered: Optional[FieldAnnotations] = pydantic.Field(
         None, description="Annotations for vaccinesAdministered"
     )
@@ -367,6 +373,9 @@ class Annotations(base_model.APIBaseModel):
         description=(
             "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
         ),
+    )
+    vaccinationsBivalentDoseRatio: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Ratio of population have received a bivalent vaccine dose."
     )
 
 
@@ -430,6 +439,9 @@ class Metrics(base_model.APIBaseModel):
         description=(
             "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
         ),
+    )
+    vaccinationsBivalentDoseRatio: Optional[float] = pydantic.Field(
+        None, description=("Ratio of population have received a bivalent vaccine dose."),
     )
 
     @staticmethod

--- a/api/data_overview_builder.py
+++ b/api/data_overview_builder.py
@@ -39,7 +39,7 @@ VACCINATION_FIELDS = Fields(
         "vaccinationsInitiated",
         "vaccinationsCompleted",
         "vaccinationsAdditionalDose",
-        "vaccinationsBivalentDose",
+        "vaccinationsFall2022BivalentBooster",
         "vaccinesAdministered",
         "vaccinesAdministeredDemographics",
         "vaccinationsInitiatedDemographics",
@@ -48,7 +48,7 @@ VACCINATION_FIELDS = Fields(
         "vaccinationsInitiatedRatio",
         "vaccinationsCompletedRatio",
         "vaccinationsAdditionalDoseRatio",
-        "vaccinationsBivalentDoseRatio",
+        "vaccinationsFall2022BivalentBoosterRatio",
     ],
 )
 

--- a/api/data_overview_builder.py
+++ b/api/data_overview_builder.py
@@ -21,11 +21,17 @@ class Fields:
     metrics: List[str]
 
 
-CASES_FIELDS = Fields(["cases", "newCases"], ["caseDensity", "infectionRate", "infectionRateCI90"],)
+CASES_FIELDS = Fields(
+    ["cases", "newCases"],
+    ["caseDensity", "infectionRate", "infectionRateCI90", "weeklyNewCasesPer100k"],
+)
 
 DEATHS_FIELDS = Fields(["deaths"], [])
 
-HOSPITALIZATIONS_FIELDS = Fields(["icuBeds", "hospitalBeds"], ["icuCapacityRatio"],)
+HOSPITALIZATIONS_FIELDS = Fields(
+    ["icuBeds", "hospitalBeds"],
+    ["icuCapacityRatio", "bedsWithCovidPatientsRatio", "weeklyCovidAdmissionsPer100k"],
+)
 
 VACCINATION_FIELDS = Fields(
     [

--- a/api/data_overview_builder.py
+++ b/api/data_overview_builder.py
@@ -33,11 +33,17 @@ VACCINATION_FIELDS = Fields(
         "vaccinationsInitiated",
         "vaccinationsCompleted",
         "vaccinationsAdditionalDose",
+        "vaccinationsBivalentDose",
         "vaccinesAdministered",
         "vaccinesAdministeredDemographics",
         "vaccinationsInitiatedDemographics",
     ],
-    ["vaccinationsInitiatedRatio", "vaccinationsCompletedRatio", "vaccinationsAdditionalDoseRatio"],
+    [
+        "vaccinationsInitiatedRatio",
+        "vaccinationsCompletedRatio",
+        "vaccinationsAdditionalDoseRatio",
+        "vaccinationsBivalentDoseRatio",
+    ],
 )
 
 

--- a/api/docs/docs/data-definitions.md
+++ b/api/docs/docs/data-definitions.md
@@ -146,7 +146,7 @@ Fields:
 
 ### Beds With Covid Patients Ratio
 
-  Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+  Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
 
 **Where to access**  
 * CSV column names: ``metrics.bedsWithCovidPatientsRatio``
@@ -154,7 +154,7 @@ Fields:
 
 ### Weekly Covid Admissions Per100K
 
-  Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+  Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
 
 **Where to access**  
 * CSV column names: ``metrics.weeklyCovidAdmissionsPer100k``
@@ -258,7 +258,7 @@ number of people vaccinated with both the first and second dose.
 
 ### Vaccinations Bivalent Dose Ratio
 
-  Ratio of population have received a bivalent vaccine dose.
+  Ratio of population that have received a bivalent vaccine dose.
 
 **Where to access**  
 * CSV column names: ``metrics.vaccinationsBivalentDoseRatio``

--- a/api/docs/docs/data-definitions.md
+++ b/api/docs/docs/data-definitions.md
@@ -202,13 +202,13 @@ number of people vaccinated with both the first and second dose.
 * CSV column names: ``actuals.vaccinationsAdditionalDose``
 * JSON file fields: ``actuals.vaccinationsAdditionalDose``, ``actualsTimeseries.*.vaccinationsAdditionalDose``
 
-### Vaccinations Bivalent Dose
+### Vaccinations Fall 2022 Bivalent Booster
 
   Number of individuals who have received a bivalent vaccine dose.
 
 **Where to access**  
-* CSV column names: ``actuals.vaccinationsBivalentDose``
-* JSON file fields: ``actuals.vaccinationsBivalentDose``, ``actualsTimeseries.*.vaccinationsBivalentDose``
+* CSV column names: ``actuals.vaccinationsFall2022BivalentBooster``
+* JSON file fields: ``actuals.vaccinationsFall2022BivalentBooster``, ``actualsTimeseries.*.vaccinationsFall2022BivalentBooster``
 
 ### Vaccines Administered
 
@@ -256,13 +256,13 @@ number of people vaccinated with both the first and second dose.
 * CSV column names: ``metrics.vaccinationsAdditionalDoseRatio``
 * JSON file fields: ``metrics.vaccinationsAdditionalDoseRatio``, ``metricsTimeseries.*.vaccinationsAdditionalDoseRatio``
 
-### Vaccinations Bivalent Dose Ratio
+### Vaccinations Fall 2022 Bivalent Booster Ratio
 
   Ratio of population that have received a bivalent vaccine dose.
 
 **Where to access**  
-* CSV column names: ``metrics.vaccinationsBivalentDoseRatio``
-* JSON file fields: ``metrics.vaccinationsBivalentDoseRatio``, ``metricsTimeseries.*.vaccinationsBivalentDoseRatio``
+* CSV column names: ``metrics.vaccinationsFall2022BivalentBoosterRatio``
+* JSON file fields: ``metrics.vaccinationsFall2022BivalentBoosterRatio``, ``metricsTimeseries.*.vaccinationsFall2022BivalentBoosterRatio``
 
 
 

--- a/api/docs/docs/data-definitions.md
+++ b/api/docs/docs/data-definitions.md
@@ -45,14 +45,6 @@ Processing steps:
 * CSV column names: ``metrics.caseDensity``
 * JSON file fields: ``metrics.caseDensity``, ``metricsTimeseries.*.caseDensity``
 
-### Weekly New Cases Per 100k Population
-
-  The number of new cases per 100k population over the last week.
-
-**Where to access**  
-* CSV column names: ``metrics.weeklyNewCasesPer100k``
-* JSON file fields: ``metrics.weeklyNewCasesPer100k``, ``metricsTimeseries.*.weeklyNewCasesPer100k``
-
 ### Infection Rate
 
   R_t, or the estimated number of infections arising from a typical case.
@@ -144,23 +136,7 @@ Fields:
 * CSV column names: ``metrics.icuCapacityRatio``
 * JSON file fields: ``metrics.icuCapacityRatio``, ``metricsTimeseries.*.icuCapacityRatio``
 
-### Beds With Covid Patients Ratio
 
-  Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using health service area data for the corresponding area. For more information on HSAs see the [Health Service Area section](https://apidocs.covidactnow.org/data-definitions/#health-service-areas)
-
-**Where to access**  
-* CSV column names: ``metrics.bedsWithCovidPatientsRatio``
-* JSON file fields: ``metrics.bedsWithCovidPatientsRatio``, ``metricsTimeseries.*.bedsWithCovidPatientsRatio``
-
-### Weekly Covid Admissions Per 100k Population
-
-  Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using health service area data for the corresponding area. For more information on HSAs see the [Health Service Area section](https://apidocs.covidactnow.org/data-definitions/#health-service-areas)
-
-**Where to access**  
-* CSV column names: ``metrics.weeklyCovidAdmissionsPer100k``
-* JSON file fields: ``metrics.weeklyCovidAdmissionsPer100k``, ``metricsTimeseries.*.weeklyCovidAdmissionsPer100k``
-
-County- and metro-level hospitalization and ICU actuals are calculated from facility-level data which, suppresses near-zero values due to privacy concerns. As a result, this data may undercount real values, particularly at low levels.
 
 ## Vaccinations
 
@@ -201,6 +177,14 @@ number of people vaccinated with both the first and second dose.
 **Where to access**  
 * CSV column names: ``actuals.vaccinationsAdditionalDose``
 * JSON file fields: ``actuals.vaccinationsAdditionalDose``, ``actualsTimeseries.*.vaccinationsAdditionalDose``
+
+### Vaccinations Bivalent Dose
+
+  Number of individuals who have received a bivalent vaccine dose.
+
+**Where to access**  
+* CSV column names: ``actuals.vaccinationsBivalentDose``
+* JSON file fields: ``actuals.vaccinationsBivalentDose``, ``actualsTimeseries.*.vaccinationsBivalentDose``
 
 ### Vaccines Administered
 
@@ -248,6 +232,14 @@ number of people vaccinated with both the first and second dose.
 * CSV column names: ``metrics.vaccinationsAdditionalDoseRatio``
 * JSON file fields: ``metrics.vaccinationsAdditionalDoseRatio``, ``metricsTimeseries.*.vaccinationsAdditionalDoseRatio``
 
+### Vaccinations Bivalent Dose Ratio
+
+  Ratio of population have received a bivalent vaccine dose.
+
+**Where to access**  
+* CSV column names: ``metrics.vaccinationsBivalentDoseRatio``
+* JSON file fields: ``metrics.vaccinationsBivalentDoseRatio``, ``metricsTimeseries.*.vaccinationsBivalentDoseRatio``
+
 
 
 ## Deaths
@@ -261,42 +253,4 @@ number of people vaccinated with both the first and second dose.
 * JSON file fields: ``actuals.deaths``, ``actualsTimeseries.*.deaths``
 
 
-## Community Levels
 
-  Community level for region.
-
-  See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
-  for details about how the Community Level is calculated and should be
-  interpreted.
-
-  The values correspond to the following levels:
-
-  | API value  | Community Level |
-  | ---------- | --------------- |
-  | 0 | Low |
-  | 1 | Medium |
-  | 2 | High |
-
-  Note that we provide two versions of the Community Level. One is called
-  `canCommunityLevel` which is calculated using CAN's data sources and is
-  available for states, counties, and metros. It is updated daily though
-  depends on hospital data which may only update weekly for counties. The
-  other is called `cdcCommunityLevel` and is the raw Community Level published
-  by the CDC. It is only available for counties and is updated on a weekly
-  basis.
-
-**Where to access**  
-* CSV column names: ``communityLevels.canCommunityLevel``
-* JSON file fields: ``communityLevels.canCommunityLevel``, ``communityLevelsTimeseries.*.canCommunityLevel``
-
-  and 
-
-* CSV column names: ``communityLevels.cdcCommunityLevel``
-* JSON file fields: ``communityLevels.cdcCommunityLevel``, ``communityLevelsTimeseries.*.cdcCommunityLevel``
-
-
-## Health Service Areas
-
-  A Health Service area (HSA) is a collection of one or more contiguous counties which are relatively self-contained with respect to hospital care. HSAs are used when calculating county-level hospital metrics in order to correct for instances where an individual county does not have any, or has few healthcare facilities within its own borders. For more information see https://seer.cancer.gov/seerstat/variables/countyattribs/hsa.html.
-
-  The source for our county to HSA mappings is [`cdc_hsa_mapping.csv`](https://raw.githubusercontent.com/covid-projections/covid-data-model/main/data/misc/cdc_hsa_mapping.csv) which follows the HSA definitions used by the CDC in their [COVID-19 Community Levels](https://www.cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html). HSA populations are calculated as the sum of the component county populations.

--- a/api/docs/docs/data-definitions.md
+++ b/api/docs/docs/data-definitions.md
@@ -277,4 +277,42 @@ number of people vaccinated with both the first and second dose.
 * JSON file fields: ``actuals.deaths``, ``actualsTimeseries.*.deaths``
 
 
+## Community Levels
 
+  Community level for region.
+
+  See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
+  for details about how the Community Level is calculated and should be
+  interpreted.
+
+  The values correspond to the following levels:
+
+  | API value  | Community Level |
+  | ---------- | --------------- |
+  | 0 | Low |
+  | 1 | Medium |
+  | 2 | High |
+
+  Note that we provide two versions of the Community Level. One is called
+  `canCommunityLevel` which is calculated using CAN's data sources and is
+  available for states, counties, and metros. It is updated daily though
+  depends on hospital data which may only update weekly for counties. The
+  other is called `cdcCommunityLevel` and is the raw Community Level published
+  by the CDC. It is only available for counties and is updated on a weekly
+  basis.
+
+**Where to access**  
+* CSV column names: ``communityLevels.canCommunityLevel``
+* JSON file fields: ``communityLevels.canCommunityLevel``, ``communityLevelsTimeseries.*.canCommunityLevel``
+
+  and 
+
+* CSV column names: ``communityLevels.cdcCommunityLevel``
+* JSON file fields: ``communityLevels.cdcCommunityLevel``, ``communityLevelsTimeseries.*.cdcCommunityLevel``
+
+
+## Health Service Areas
+
+  A Health Service area (HSA) is a collection of one or more contiguous counties which are relatively self-contained with respect to hospital care. HSAs are used when calculating county-level hospital metrics in order to correct for instances where an individual county does not have any, or has few healthcare facilities within its own borders. For more information see https://seer.cancer.gov/seerstat/variables/countyattribs/hsa.html.
+
+  The source for our county to HSA mappings is [`cdc_hsa_mapping.csv`](https://raw.githubusercontent.com/covid-projections/covid-data-model/main/data/misc/cdc_hsa_mapping.csv) which follows the HSA definitions used by the CDC in their [COVID-19 Community Levels](https://www.cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html). HSA populations are calculated as the sum of the component county populations.

--- a/api/docs/docs/data-definitions.md
+++ b/api/docs/docs/data-definitions.md
@@ -61,6 +61,14 @@ Processing steps:
 * CSV column names: ``metrics.infectionRateCI90``
 * JSON file fields: ``metrics.infectionRateCI90``, ``metricsTimeseries.*.infectionRateCI90``
 
+### Weekly New Cases Per100K
+
+  The number of new cases per 100k population over the last week.
+
+**Where to access**  
+* CSV column names: ``metrics.weeklyNewCasesPer100k``
+* JSON file fields: ``metrics.weeklyNewCasesPer100k``, ``metricsTimeseries.*.weeklyNewCasesPer100k``
+
 
 
 ## Tests
@@ -135,6 +143,22 @@ Fields:
 **Where to access**  
 * CSV column names: ``metrics.icuCapacityRatio``
 * JSON file fields: ``metrics.icuCapacityRatio``, ``metricsTimeseries.*.icuCapacityRatio``
+
+### Beds With Covid Patients Ratio
+
+  Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+
+**Where to access**  
+* CSV column names: ``metrics.bedsWithCovidPatientsRatio``
+* JSON file fields: ``metrics.bedsWithCovidPatientsRatio``, ``metricsTimeseries.*.bedsWithCovidPatientsRatio``
+
+### Weekly Covid Admissions Per100K
+
+  Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+
+**Where to access**  
+* CSV column names: ``metrics.weeklyCovidAdmissionsPer100k``
+* JSON file fields: ``metrics.weeklyCovidAdmissionsPer100k``, ``metricsTimeseries.*.weeklyCovidAdmissionsPer100k``
 
 
 

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -1359,7 +1359,7 @@
                 "$ref": "#/components/schemas/HospitalResourceUtilizationWithAdmissions"
               }
             ],
-            "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n"
+            "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n"
           },
           "icuBeds": {
             "title": "Icubeds",
@@ -1377,7 +1377,7 @@
                 "$ref": "#/components/schemas/HospitalResourceUtilization"
               }
             ],
-            "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n"
+            "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n"
           },
           "newCases": {
             "title": "Newcases",
@@ -1645,7 +1645,7 @@
                 "type": "null"
               }
             ],
-            "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area."
+            "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas"
           },
           "weeklyCovidAdmissionsPer100k": {
             "title": "Weeklycovidadmissionsper100K",
@@ -1657,7 +1657,7 @@
                 "type": "null"
               }
             ],
-            "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area."
+            "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas"
           },
           "vaccinationsInitiatedRatio": {
             "title": "Vaccinationsinitiatedratio",
@@ -1705,7 +1705,7 @@
                 "type": "null"
               }
             ],
-            "description": "Ratio of population have received a bivalent vaccine dose."
+            "description": "Ratio of population that have received a bivalent vaccine dose."
           }
         },
         "description": "Calculated metrics data based on known actuals."
@@ -1939,7 +1939,7 @@
                 "type": "null"
               }
             ],
-            "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+            "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
           },
           "hsaName": {
             "title": "Hsaname",
@@ -1951,7 +1951,7 @@
                 "type": "null"
               }
             ],
-            "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+            "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
           },
           "hsaPopulation": {
             "title": "Hsapopulation",
@@ -1964,7 +1964,7 @@
                 "type": "null"
               }
             ],
-            "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+            "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
           },
           "communityLevels": {
             "title": "Communitylevels",
@@ -2480,7 +2480,7 @@
                 "$ref": "#/components/schemas/FieldAnnotations"
               }
             ],
-            "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
+            "description": "Annotations for vaccinationsAdditionalDoseRatio"
           },
           "vaccinationsBivalentDoseRatio": {
             "title": "Vaccinationsbivalentdoseratio",
@@ -2489,7 +2489,7 @@
                 "$ref": "#/components/schemas/FieldAnnotations"
               }
             ],
-            "description": "Ratio of population have received a bivalent vaccine dose."
+            "description": "Annotations for vaccinationsBivalentDoseRatio."
           }
         },
         "description": "Annotations for each field."
@@ -2564,7 +2564,7 @@
                 "type": "null"
               }
             ],
-            "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+            "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
           },
           "hsaName": {
             "title": "Hsaname",
@@ -2576,7 +2576,7 @@
                 "type": "null"
               }
             ],
-            "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+            "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
           },
           "level": {
             "allOf": [
@@ -2632,7 +2632,7 @@
                 "type": "null"
               }
             ],
-            "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+            "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
           },
           "metrics": {
             "$ref": "#/components/schemas/Metrics"
@@ -2812,7 +2812,7 @@
                 "type": "null"
               }
             ],
-            "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area."
+            "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas"
           },
           "weeklyCovidAdmissionsPer100k": {
             "title": "Weeklycovidadmissionsper100K",
@@ -2824,7 +2824,7 @@
                 "type": "null"
               }
             ],
-            "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area."
+            "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas"
           },
           "vaccinationsInitiatedRatio": {
             "title": "Vaccinationsinitiatedratio",
@@ -2872,7 +2872,7 @@
                 "type": "null"
               }
             ],
-            "description": "Ratio of population have received a bivalent vaccine dose."
+            "description": "Ratio of population that have received a bivalent vaccine dose."
           },
           "date": {
             "title": "Date",
@@ -2977,7 +2977,7 @@
                 "$ref": "#/components/schemas/HospitalResourceUtilizationWithAdmissions"
               }
             ],
-            "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n"
+            "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n"
           },
           "icuBeds": {
             "title": "Icubeds",
@@ -2995,7 +2995,7 @@
                 "$ref": "#/components/schemas/HospitalResourceUtilization"
               }
             ],
-            "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n"
+            "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n"
           },
           "newCases": {
             "title": "Newcases",
@@ -3254,7 +3254,7 @@
                 "type": "null"
               }
             ],
-            "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+            "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
           },
           "hsaName": {
             "title": "Hsaname",
@@ -3266,7 +3266,7 @@
                 "type": "null"
               }
             ],
-            "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+            "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
           },
           "level": {
             "allOf": [
@@ -3322,7 +3322,7 @@
                 "type": "null"
               }
             ],
-            "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+            "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
           },
           "metrics": {
             "$ref": "#/components/schemas/Metrics"

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -1451,8 +1451,8 @@
             ],
             "description": "Number of individuals who are fully vaccinated and have received a booster (or additional) dose."
           },
-          "vaccinationsBivalentDose": {
-            "title": "Vaccinationsbivalentdose",
+          "vaccinationsFall2022BivalentBooster": {
+            "title": "Vaccinationsfall2022Bivalentbooster",
             "anyOf": [
               {
                 "type": "integer"
@@ -1695,8 +1695,8 @@
             ],
             "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
           },
-          "vaccinationsBivalentDoseRatio": {
-            "title": "Vaccinationsbivalentdoseratio",
+          "vaccinationsFall2022BivalentBoosterRatio": {
+            "title": "Vaccinationsfall2022Bivalentboosterratio",
             "anyOf": [
               {
                 "type": "number"
@@ -2356,14 +2356,14 @@
             ],
             "description": "Annotations for vaccinationsAdditionalDose"
           },
-          "vaccinationsBivalentDose": {
-            "title": "Vaccinationsbivalentdose",
+          "vaccinationsFall2022BivalentBooster": {
+            "title": "Vaccinationsfall2022Bivalentbooster",
             "allOf": [
               {
                 "$ref": "#/components/schemas/FieldAnnotations"
               }
             ],
-            "description": "Annotations for vaccinationsBivalentDose"
+            "description": "Annotations for vaccinationsFall2022BivalentBooster"
           },
           "vaccinesAdministered": {
             "title": "Vaccinesadministered",
@@ -2482,14 +2482,14 @@
             ],
             "description": "Annotations for vaccinationsAdditionalDoseRatio"
           },
-          "vaccinationsBivalentDoseRatio": {
-            "title": "Vaccinationsbivalentdoseratio",
+          "vaccinationsFall2022BivalentBoosterRatio": {
+            "title": "Vaccinationsfall2022Bivalentboosterratio",
             "allOf": [
               {
                 "$ref": "#/components/schemas/FieldAnnotations"
               }
             ],
-            "description": "Annotations for vaccinationsBivalentDoseRatio."
+            "description": "Annotations for vaccinationsFall2022BivalentBoosterRatio."
           }
         },
         "description": "Annotations for each field."
@@ -2862,8 +2862,8 @@
             ],
             "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
           },
-          "vaccinationsBivalentDoseRatio": {
-            "title": "Vaccinationsbivalentdoseratio",
+          "vaccinationsFall2022BivalentBoosterRatio": {
+            "title": "Vaccinationsfall2022Bivalentboosterratio",
             "anyOf": [
               {
                 "type": "number"
@@ -3069,8 +3069,8 @@
             ],
             "description": "Number of individuals who are fully vaccinated and have received a booster (or additional) dose."
           },
-          "vaccinationsBivalentDose": {
-            "title": "Vaccinationsbivalentdose",
+          "vaccinationsFall2022BivalentBooster": {
+            "title": "Vaccinationsfall2022Bivalentbooster",
             "anyOf": [
               {
                 "type": "integer"

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -1451,6 +1451,18 @@
             ],
             "description": "Number of individuals who are fully vaccinated and have received a booster (or additional) dose."
           },
+          "vaccinationsBivalentDose": {
+            "title": "Vaccinationsbivalentdose",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Number of individuals who have received a bivalent vaccine dose."
+          },
           "vaccinesAdministered": {
             "title": "Vaccinesadministered",
             "anyOf": [
@@ -1682,6 +1694,18 @@
               }
             ],
             "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
+          },
+          "vaccinationsBivalentDoseRatio": {
+            "title": "Vaccinationsbivalentdoseratio",
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Ratio of population have received a bivalent vaccine dose."
           }
         },
         "description": "Calculated metrics data based on known actuals."
@@ -1712,7 +1736,7 @@
                 "$ref": "#/components/schemas/RiskLevel"
               }
             ],
-            "description": "Overall risk level for region ."
+            "description": "Overall risk level for region."
           },
           "caseDensity": {
             "allOf": [
@@ -1760,7 +1784,7 @@
                 "$ref": "#/components/schemas/CommunityLevel"
               }
             ],
-            "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n"
+            "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n"
           },
           "canCommunityLevel": {
             "allOf": [
@@ -1768,7 +1792,7 @@
                 "$ref": "#/components/schemas/CommunityLevel"
               }
             ],
-            "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n"
+            "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n"
           },
           "date": {
             "title": "Date",
@@ -1796,7 +1820,8 @@
           "cdcTransmissionLevel",
           "hsa",
           "hsaName",
-          "hsaPopulation"
+          "hsaPopulation",
+          "communityLevels"
         ],
         "type": "object",
         "properties": {
@@ -1942,14 +1967,13 @@
             "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
           },
           "communityLevels": {
-            "anyOf": [
+            "title": "Communitylevels",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/CommunityLevelsTimeseriesRow"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "description": "Community levels for any given day"
           }
         },
         "description": "Prediction timeseries row with location information."
@@ -2051,7 +2075,7 @@
                 "$ref": "#/components/schemas/CommunityLevel"
               }
             ],
-            "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n"
+            "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n"
           },
           "canCommunityLevel": {
             "allOf": [
@@ -2059,7 +2083,7 @@
                 "$ref": "#/components/schemas/CommunityLevel"
               }
             ],
-            "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n"
+            "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n"
           }
         },
         "description": "Community levels for a region."
@@ -2332,6 +2356,15 @@
             ],
             "description": "Annotations for vaccinationsAdditionalDose"
           },
+          "vaccinationsBivalentDose": {
+            "title": "Vaccinationsbivalentdose",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for vaccinationsBivalentDose"
+          },
           "vaccinesAdministered": {
             "title": "Vaccinesadministered",
             "allOf": [
@@ -2448,6 +2481,15 @@
               }
             ],
             "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
+          },
+          "vaccinationsBivalentDoseRatio": {
+            "title": "Vaccinationsbivalentdoseratio",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Ratio of population have received a bivalent vaccine dose."
           }
         },
         "description": "Annotations for each field."
@@ -2820,6 +2862,18 @@
             ],
             "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose."
           },
+          "vaccinationsBivalentDoseRatio": {
+            "title": "Vaccinationsbivalentdoseratio",
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Ratio of population have received a bivalent vaccine dose."
+          },
           "date": {
             "title": "Date",
             "type": "string",
@@ -3015,6 +3069,18 @@
             ],
             "description": "Number of individuals who are fully vaccinated and have received a booster (or additional) dose."
           },
+          "vaccinationsBivalentDose": {
+            "title": "Vaccinationsbivalentdose",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Number of individuals who have received a bivalent vaccine dose."
+          },
           "vaccinesAdministered": {
             "title": "Vaccinesadministered",
             "anyOf": [
@@ -3069,7 +3135,7 @@
                 "$ref": "#/components/schemas/RiskLevel"
               }
             ],
-            "description": "Overall risk level for region ."
+            "description": "Overall risk level for region."
           },
           "caseDensity": {
             "allOf": [

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -74,7 +74,7 @@
     },
     "hsaHospitalBeds": {
       "title": "Hsahospitalbeds",
-      "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+      "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
       "allOf": [
         {
           "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -92,7 +92,7 @@
     },
     "hsaIcuBeds": {
       "title": "Hsaicubeds",
-      "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+      "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
       "allOf": [
         {
           "$ref": "#/definitions/HospitalResourceUtilization"

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -171,8 +171,8 @@
         }
       ]
     },
-    "vaccinationsBivalentDose": {
-      "title": "Vaccinationsbivalentdose",
+    "vaccinationsFall2022BivalentBooster": {
+      "title": "Vaccinationsfall2022Bivalentbooster",
       "description": "Number of individuals who have received a bivalent vaccine dose.",
       "anyOf": [
         {

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -171,6 +171,18 @@
         }
       ]
     },
+    "vaccinationsBivalentDose": {
+      "title": "Vaccinationsbivalentdose",
+      "description": "Number of individuals who have received a bivalent vaccine dose.",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "vaccinesAdministered": {
       "title": "Vaccinesadministered",
       "description": "Total number of vaccine doses administered.",

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -74,7 +74,7 @@
     },
     "hsaHospitalBeds": {
       "title": "Hsahospitalbeds",
-      "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+      "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
       "allOf": [
         {
           "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -92,7 +92,7 @@
     },
     "hsaIcuBeds": {
       "title": "Hsaicubeds",
-      "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+      "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
       "allOf": [
         {
           "$ref": "#/definitions/HospitalResourceUtilization"

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -171,8 +171,8 @@
         }
       ]
     },
-    "vaccinationsBivalentDose": {
-      "title": "Vaccinationsbivalentdose",
+    "vaccinationsFall2022BivalentBooster": {
+      "title": "Vaccinationsfall2022Bivalentbooster",
       "description": "Number of individuals who have received a bivalent vaccine dose.",
       "anyOf": [
         {

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -171,6 +171,18 @@
         }
       ]
     },
+    "vaccinationsBivalentDose": {
+      "title": "Vaccinationsbivalentdose",
+      "description": "Number of individuals who have received a bivalent vaccine dose.",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "vaccinesAdministered": {
       "title": "Vaccinesadministered",
       "description": "Total number of vaccine doses administered.",

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -254,7 +254,7 @@
         },
         "hsaHospitalBeds": {
           "title": "Hsahospitalbeds",
-          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -272,7 +272,7 @@
         },
         "hsaIcuBeds": {
           "title": "Hsaicubeds",
-          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilization"
@@ -539,7 +539,7 @@
         },
         "bedsWithCovidPatientsRatio": {
           "title": "Bedswithcovidpatientsratio",
-          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -551,7 +551,7 @@
         },
         "weeklyCovidAdmissionsPer100k": {
           "title": "Weeklycovidadmissionsper100K",
-          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -599,7 +599,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"
@@ -826,7 +826,7 @@
         },
         "hsa": {
           "title": "Hsa",
-          "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+          "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
           "anyOf": [
             {
               "type": "string"
@@ -838,7 +838,7 @@
         },
         "hsaName": {
           "title": "Hsaname",
-          "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+          "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
           "anyOf": [
             {
               "type": "string"
@@ -850,7 +850,7 @@
         },
         "hsaPopulation": {
           "title": "Hsapopulation",
-          "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+          "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
           "exclusiveMinimum": 0,
           "anyOf": [
             {

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -351,6 +351,18 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Number of individuals who have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Total number of vaccine doses administered.",
@@ -584,6 +596,18 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -616,7 +640,7 @@
       "type": "object",
       "properties": {
         "overall": {
-          "description": "Overall risk level for region .",
+          "description": "Overall risk level for region.",
           "allOf": [
             {
               "$ref": "#/definitions/RiskLevel"
@@ -663,7 +687,7 @@
       "type": "object",
       "properties": {
         "cdcCommunityLevel": {
-          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -671,7 +695,7 @@
           ]
         },
         "canCommunityLevel": {
-          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -838,12 +862,11 @@
           ]
         },
         "communityLevels": {
-          "anyOf": [
+          "title": "Communitylevels",
+          "description": "Community levels for any given day",
+          "allOf": [
             {
               "$ref": "#/definitions/CommunityLevelsTimeseriesRow"
-            },
-            {
-              "type": "null"
             }
           ]
         }
@@ -863,7 +886,8 @@
         "cdcTransmissionLevel",
         "hsa",
         "hsaName",
-        "hsaPopulation"
+        "hsaPopulation",
+        "communityLevels"
       ]
     }
   }

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -351,8 +351,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
           "description": "Number of individuals who have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -597,8 +597,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
           "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -149,7 +149,7 @@
         },
         "bedsWithCovidPatientsRatio": {
           "title": "Bedswithcovidpatientsratio",
-          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -161,7 +161,7 @@
         },
         "weeklyCovidAdmissionsPer100k": {
           "title": "Weeklycovidadmissionsper100K",
-          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -209,7 +209,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"
@@ -602,7 +602,7 @@
         },
         "hsaHospitalBeds": {
           "title": "Hsahospitalbeds",
-          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -620,7 +620,7 @@
         },
         "hsaIcuBeds": {
           "title": "Hsaicubeds",
-          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilization"
@@ -1144,7 +1144,7 @@
         },
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
-          "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "description": "Annotations for vaccinationsAdditionalDoseRatio",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1153,7 +1153,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Annotations for vaccinationsBivalentDoseRatio.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1203,7 +1203,7 @@
         },
         "hsa": {
           "title": "Hsa",
-          "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+          "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
           "anyOf": [
             {
               "type": "string"
@@ -1215,7 +1215,7 @@
         },
         "hsaName": {
           "title": "Hsaname",
-          "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+          "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
           "anyOf": [
             {
               "type": "string"
@@ -1270,7 +1270,7 @@
         },
         "hsaPopulation": {
           "title": "Hsapopulation",
-          "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+          "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
           "exclusiveMinimum": 0,
           "anyOf": [
             {

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -206,6 +206,18 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -321,7 +333,7 @@
       "type": "object",
       "properties": {
         "cdcCommunityLevel": {
-          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -329,7 +341,7 @@
           ]
         },
         "canCommunityLevel": {
-          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -687,6 +699,18 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Number of individuals who have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Total number of vaccine doses administered.",
@@ -1001,6 +1025,15 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Annotations for vaccinationsBivalentDose",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Annotations for vaccinesAdministered",
@@ -1112,6 +1145,15 @@
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
           "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -207,8 +207,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
           "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -699,8 +699,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
           "description": "Number of individuals who have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -1025,9 +1025,9 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
-          "description": "Annotations for vaccinationsBivalentDose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
+          "description": "Annotations for vaccinationsFall2022BivalentBooster",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1151,9 +1151,9 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
-          "description": "Annotations for vaccinationsBivalentDoseRatio.",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
+          "description": "Annotations for vaccinationsFall2022BivalentBoosterRatio.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -149,7 +149,7 @@
         },
         "bedsWithCovidPatientsRatio": {
           "title": "Bedswithcovidpatientsratio",
-          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -161,7 +161,7 @@
         },
         "weeklyCovidAdmissionsPer100k": {
           "title": "Weeklycovidadmissionsper100K",
-          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -209,7 +209,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"
@@ -602,7 +602,7 @@
         },
         "hsaHospitalBeds": {
           "title": "Hsahospitalbeds",
-          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -620,7 +620,7 @@
         },
         "hsaIcuBeds": {
           "title": "Hsaicubeds",
-          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilization"
@@ -1144,7 +1144,7 @@
         },
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
-          "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "description": "Annotations for vaccinationsAdditionalDoseRatio",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1153,7 +1153,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Annotations for vaccinationsBivalentDoseRatio.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1263,7 +1263,7 @@
         },
         "bedsWithCovidPatientsRatio": {
           "title": "Bedswithcovidpatientsratio",
-          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -1275,7 +1275,7 @@
         },
         "weeklyCovidAdmissionsPer100k": {
           "title": "Weeklycovidadmissionsper100K",
-          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -1323,7 +1323,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"
@@ -1429,7 +1429,7 @@
         },
         "hsaHospitalBeds": {
           "title": "Hsahospitalbeds",
-          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -1447,7 +1447,7 @@
         },
         "hsaIcuBeds": {
           "title": "Hsaicubeds",
-          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilization"
@@ -1724,7 +1724,7 @@
         },
         "hsa": {
           "title": "Hsa",
-          "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+          "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
           "anyOf": [
             {
               "type": "string"
@@ -1736,7 +1736,7 @@
         },
         "hsaName": {
           "title": "Hsaname",
-          "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+          "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
           "anyOf": [
             {
               "type": "string"
@@ -1791,7 +1791,7 @@
         },
         "hsaPopulation": {
           "title": "Hsapopulation",
-          "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+          "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
           "exclusiveMinimum": 0,
           "anyOf": [
             {

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -207,8 +207,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
           "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -699,8 +699,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
           "description": "Number of individuals who have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -1025,9 +1025,9 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
-          "description": "Annotations for vaccinationsBivalentDose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
+          "description": "Annotations for vaccinationsFall2022BivalentBooster",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1151,9 +1151,9 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
-          "description": "Annotations for vaccinationsBivalentDoseRatio.",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
+          "description": "Annotations for vaccinationsFall2022BivalentBoosterRatio.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1321,8 +1321,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
           "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -1526,8 +1526,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
           "description": "Number of individuals who have received a bivalent vaccine dose.",
           "anyOf": [
             {

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -206,6 +206,18 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -321,7 +333,7 @@
       "type": "object",
       "properties": {
         "cdcCommunityLevel": {
-          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -329,7 +341,7 @@
           ]
         },
         "canCommunityLevel": {
-          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -687,6 +699,18 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Number of individuals who have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Total number of vaccine doses administered.",
@@ -1001,6 +1025,15 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Annotations for vaccinationsBivalentDose",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Annotations for vaccinesAdministered",
@@ -1112,6 +1145,15 @@
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
           "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1270,6 +1312,18 @@
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
           "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"
@@ -1472,6 +1526,18 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Number of individuals who have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Total number of vaccine doses administered.",
@@ -1530,7 +1596,7 @@
       "type": "object",
       "properties": {
         "overall": {
-          "description": "Overall risk level for region .",
+          "description": "Overall risk level for region.",
           "allOf": [
             {
               "$ref": "#/definitions/RiskLevel"
@@ -1589,7 +1655,7 @@
       "type": "object",
       "properties": {
         "cdcCommunityLevel": {
-          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -1597,7 +1663,7 @@
           ]
         },
         "canCommunityLevel": {
-          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"

--- a/api/schemas_v2/Annotations.json
+++ b/api/schemas_v2/Annotations.json
@@ -138,9 +138,9 @@
         }
       ]
     },
-    "vaccinationsBivalentDose": {
-      "title": "Vaccinationsbivalentdose",
-      "description": "Annotations for vaccinationsBivalentDose",
+    "vaccinationsFall2022BivalentBooster": {
+      "title": "Vaccinationsfall2022Bivalentbooster",
+      "description": "Annotations for vaccinationsFall2022BivalentBooster",
       "allOf": [
         {
           "$ref": "#/definitions/FieldAnnotations"
@@ -264,9 +264,9 @@
         }
       ]
     },
-    "vaccinationsBivalentDoseRatio": {
-      "title": "Vaccinationsbivalentdoseratio",
-      "description": "Annotations for vaccinationsBivalentDoseRatio.",
+    "vaccinationsFall2022BivalentBoosterRatio": {
+      "title": "Vaccinationsfall2022Bivalentboosterratio",
+      "description": "Annotations for vaccinationsFall2022BivalentBoosterRatio.",
       "allOf": [
         {
           "$ref": "#/definitions/FieldAnnotations"

--- a/api/schemas_v2/Annotations.json
+++ b/api/schemas_v2/Annotations.json
@@ -257,7 +257,7 @@
     },
     "vaccinationsAdditionalDoseRatio": {
       "title": "Vaccinationsadditionaldoseratio",
-      "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+      "description": "Annotations for vaccinationsAdditionalDoseRatio",
       "allOf": [
         {
           "$ref": "#/definitions/FieldAnnotations"
@@ -266,7 +266,7 @@
     },
     "vaccinationsBivalentDoseRatio": {
       "title": "Vaccinationsbivalentdoseratio",
-      "description": "Ratio of population have received a bivalent vaccine dose.",
+      "description": "Annotations for vaccinationsBivalentDoseRatio.",
       "allOf": [
         {
           "$ref": "#/definitions/FieldAnnotations"

--- a/api/schemas_v2/Annotations.json
+++ b/api/schemas_v2/Annotations.json
@@ -138,6 +138,15 @@
         }
       ]
     },
+    "vaccinationsBivalentDose": {
+      "title": "Vaccinationsbivalentdose",
+      "description": "Annotations for vaccinationsBivalentDose",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FieldAnnotations"
+        }
+      ]
+    },
     "vaccinesAdministered": {
       "title": "Vaccinesadministered",
       "description": "Annotations for vaccinesAdministered",
@@ -249,6 +258,15 @@
     "vaccinationsAdditionalDoseRatio": {
       "title": "Vaccinationsadditionaldoseratio",
       "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FieldAnnotations"
+        }
+      ]
+    },
+    "vaccinationsBivalentDoseRatio": {
+      "title": "Vaccinationsbivalentdoseratio",
+      "description": "Ratio of population have received a bivalent vaccine dose.",
       "allOf": [
         {
           "$ref": "#/definitions/FieldAnnotations"

--- a/api/schemas_v2/CommunityLevels.json
+++ b/api/schemas_v2/CommunityLevels.json
@@ -4,7 +4,7 @@
   "type": "object",
   "properties": {
     "cdcCommunityLevel": {
-      "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+      "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
       "allOf": [
         {
           "$ref": "#/definitions/CommunityLevel"
@@ -12,7 +12,7 @@
       ]
     },
     "canCommunityLevel": {
-      "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+      "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
       "allOf": [
         {
           "$ref": "#/definitions/CommunityLevel"

--- a/api/schemas_v2/CommunityLevelsTimeseriesRow.json
+++ b/api/schemas_v2/CommunityLevelsTimeseriesRow.json
@@ -4,7 +4,7 @@
   "type": "object",
   "properties": {
     "cdcCommunityLevel": {
-      "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+      "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
       "allOf": [
         {
           "$ref": "#/definitions/CommunityLevel"
@@ -12,7 +12,7 @@
       ]
     },
     "canCommunityLevel": {
-      "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+      "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
       "allOf": [
         {
           "$ref": "#/definitions/CommunityLevel"

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -99,7 +99,7 @@
     },
     "bedsWithCovidPatientsRatio": {
       "title": "Bedswithcovidpatientsratio",
-      "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+      "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
       "anyOf": [
         {
           "type": "number"
@@ -111,7 +111,7 @@
     },
     "weeklyCovidAdmissionsPer100k": {
       "title": "Weeklycovidadmissionsper100K",
-      "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+      "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
       "anyOf": [
         {
           "type": "number"
@@ -159,7 +159,7 @@
     },
     "vaccinationsBivalentDoseRatio": {
       "title": "Vaccinationsbivalentdoseratio",
-      "description": "Ratio of population have received a bivalent vaccine dose.",
+      "description": "Ratio of population that have received a bivalent vaccine dose.",
       "anyOf": [
         {
           "type": "number"

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -156,6 +156,18 @@
           "type": "null"
         }
       ]
+    },
+    "vaccinationsBivalentDoseRatio": {
+      "title": "Vaccinationsbivalentdoseratio",
+      "description": "Ratio of population have received a bivalent vaccine dose.",
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -157,8 +157,8 @@
         }
       ]
     },
-    "vaccinationsBivalentDoseRatio": {
-      "title": "Vaccinationsbivalentdoseratio",
+    "vaccinationsFall2022BivalentBoosterRatio": {
+      "title": "Vaccinationsfall2022Bivalentboosterratio",
       "description": "Ratio of population that have received a bivalent vaccine dose.",
       "anyOf": [
         {

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -157,6 +157,18 @@
         }
       ]
     },
+    "vaccinationsBivalentDoseRatio": {
+      "title": "Vaccinationsbivalentdoseratio",
+      "description": "Ratio of population have received a bivalent vaccine dose.",
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "date": {
       "title": "Date",
       "description": "Date of timeseries data point",

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -99,7 +99,7 @@
     },
     "bedsWithCovidPatientsRatio": {
       "title": "Bedswithcovidpatientsratio",
-      "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+      "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
       "anyOf": [
         {
           "type": "number"
@@ -111,7 +111,7 @@
     },
     "weeklyCovidAdmissionsPer100k": {
       "title": "Weeklycovidadmissionsper100K",
-      "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+      "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
       "anyOf": [
         {
           "type": "number"
@@ -159,7 +159,7 @@
     },
     "vaccinationsBivalentDoseRatio": {
       "title": "Vaccinationsbivalentdoseratio",
-      "description": "Ratio of population have received a bivalent vaccine dose.",
+      "description": "Ratio of population that have received a bivalent vaccine dose.",
       "anyOf": [
         {
           "type": "number"

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -157,8 +157,8 @@
         }
       ]
     },
-    "vaccinationsBivalentDoseRatio": {
-      "title": "Vaccinationsbivalentdoseratio",
+    "vaccinationsFall2022BivalentBoosterRatio": {
+      "title": "Vaccinationsfall2022Bivalentboosterratio",
       "description": "Ratio of population that have received a bivalent vaccine dose.",
       "anyOf": [
         {

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -388,6 +388,18 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -503,7 +515,7 @@
       "type": "object",
       "properties": {
         "cdcCommunityLevel": {
-          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -511,7 +523,7 @@
           ]
         },
         "canCommunityLevel": {
-          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -869,6 +881,18 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Number of individuals who have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Total number of vaccine doses administered.",
@@ -1183,6 +1207,15 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Annotations for vaccinationsBivalentDose",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Annotations for vaccinesAdministered",
@@ -1294,6 +1327,15 @@
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
           "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -389,8 +389,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
           "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -881,8 +881,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
           "description": "Number of individuals who have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -1207,9 +1207,9 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
-          "description": "Annotations for vaccinationsBivalentDose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
+          "description": "Annotations for vaccinationsFall2022BivalentBooster",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1333,9 +1333,9 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
-          "description": "Annotations for vaccinationsBivalentDoseRatio.",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
+          "description": "Annotations for vaccinationsFall2022BivalentBoosterRatio.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -39,7 +39,7 @@
     },
     "hsa": {
       "title": "Hsa",
-      "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+      "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
       "anyOf": [
         {
           "type": "string"
@@ -51,7 +51,7 @@
     },
     "hsaName": {
       "title": "Hsaname",
-      "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+      "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
       "anyOf": [
         {
           "type": "string"
@@ -106,7 +106,7 @@
     },
     "hsaPopulation": {
       "title": "Hsapopulation",
-      "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+      "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
       "exclusiveMinimum": 0,
       "anyOf": [
         {
@@ -331,7 +331,7 @@
         },
         "bedsWithCovidPatientsRatio": {
           "title": "Bedswithcovidpatientsratio",
-          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -343,7 +343,7 @@
         },
         "weeklyCovidAdmissionsPer100k": {
           "title": "Weeklycovidadmissionsper100K",
-          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -391,7 +391,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"
@@ -784,7 +784,7 @@
         },
         "hsaHospitalBeds": {
           "title": "Hsahospitalbeds",
-          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -802,7 +802,7 @@
         },
         "hsaIcuBeds": {
           "title": "Hsaicubeds",
-          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilization"
@@ -1326,7 +1326,7 @@
         },
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
-          "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "description": "Annotations for vaccinationsAdditionalDoseRatio",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1335,7 +1335,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Annotations for vaccinationsBivalentDoseRatio.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -429,8 +429,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
           "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -921,8 +921,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
           "description": "Number of individuals who have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -1247,9 +1247,9 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
-          "description": "Annotations for vaccinationsBivalentDose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
+          "description": "Annotations for vaccinationsFall2022BivalentBooster",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1373,9 +1373,9 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
-          "description": "Annotations for vaccinationsBivalentDoseRatio.",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
+          "description": "Annotations for vaccinationsFall2022BivalentBoosterRatio.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1543,8 +1543,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
           "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -1748,8 +1748,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
           "description": "Number of individuals who have received a bivalent vaccine dose.",
           "anyOf": [
             {

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -428,6 +428,18 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -543,7 +555,7 @@
       "type": "object",
       "properties": {
         "cdcCommunityLevel": {
-          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -551,7 +563,7 @@
           ]
         },
         "canCommunityLevel": {
-          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -909,6 +921,18 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Number of individuals who have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Total number of vaccine doses administered.",
@@ -1223,6 +1247,15 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Annotations for vaccinationsBivalentDose",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Annotations for vaccinesAdministered",
@@ -1334,6 +1367,15 @@
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
           "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1492,6 +1534,18 @@
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
           "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"
@@ -1694,6 +1748,18 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Number of individuals who have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Total number of vaccine doses administered.",
@@ -1752,7 +1818,7 @@
       "type": "object",
       "properties": {
         "overall": {
-          "description": "Overall risk level for region .",
+          "description": "Overall risk level for region.",
           "allOf": [
             {
               "$ref": "#/definitions/RiskLevel"
@@ -1811,7 +1877,7 @@
       "type": "object",
       "properties": {
         "cdcCommunityLevel": {
-          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -1819,7 +1885,7 @@
           ]
         },
         "canCommunityLevel": {
-          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -39,7 +39,7 @@
     },
     "hsa": {
       "title": "Hsa",
-      "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+      "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
       "anyOf": [
         {
           "type": "string"
@@ -51,7 +51,7 @@
     },
     "hsaName": {
       "title": "Hsaname",
-      "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+      "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
       "anyOf": [
         {
           "type": "string"
@@ -106,7 +106,7 @@
     },
     "hsaPopulation": {
       "title": "Hsapopulation",
-      "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+      "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
       "exclusiveMinimum": 0,
       "anyOf": [
         {
@@ -371,7 +371,7 @@
         },
         "bedsWithCovidPatientsRatio": {
           "title": "Bedswithcovidpatientsratio",
-          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -383,7 +383,7 @@
         },
         "weeklyCovidAdmissionsPer100k": {
           "title": "Weeklycovidadmissionsper100K",
-          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -431,7 +431,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"
@@ -824,7 +824,7 @@
         },
         "hsaHospitalBeds": {
           "title": "Hsahospitalbeds",
-          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -842,7 +842,7 @@
         },
         "hsaIcuBeds": {
           "title": "Hsaicubeds",
-          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilization"
@@ -1366,7 +1366,7 @@
         },
         "vaccinationsAdditionalDoseRatio": {
           "title": "Vaccinationsadditionaldoseratio",
-          "description": "Ratio of population that are fully vaccinated and have received a booster (or additional) dose.",
+          "description": "Annotations for vaccinationsAdditionalDoseRatio",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1375,7 +1375,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Annotations for vaccinationsBivalentDoseRatio.",
           "allOf": [
             {
               "$ref": "#/definitions/FieldAnnotations"
@@ -1485,7 +1485,7 @@
         },
         "bedsWithCovidPatientsRatio": {
           "title": "Bedswithcovidpatientsratio",
-          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -1497,7 +1497,7 @@
         },
         "weeklyCovidAdmissionsPer100k": {
           "title": "Weeklycovidadmissionsper100K",
-          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -1545,7 +1545,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"
@@ -1651,7 +1651,7 @@
         },
         "hsaHospitalBeds": {
           "title": "Hsahospitalbeds",
-          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -1669,7 +1669,7 @@
         },
         "hsaIcuBeds": {
           "title": "Hsaicubeds",
-          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilization"

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -145,12 +145,11 @@
       ]
     },
     "communityLevels": {
-      "anyOf": [
+      "title": "Communitylevels",
+      "description": "Community levels for any given day",
+      "allOf": [
         {
           "$ref": "#/definitions/CommunityLevelsTimeseriesRow"
-        },
-        {
-          "type": "null"
         }
       ]
     }
@@ -170,7 +169,8 @@
     "cdcTransmissionLevel",
     "hsa",
     "hsaName",
-    "hsaPopulation"
+    "hsaPopulation",
+    "communityLevels"
   ],
   "definitions": {
     "HospitalResourceUtilizationWithAdmissions": {
@@ -518,6 +518,18 @@
             }
           ]
         },
+        "vaccinationsBivalentDose": {
+          "title": "Vaccinationsbivalentdose",
+          "description": "Number of individuals who have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "vaccinesAdministered": {
           "title": "Vaccinesadministered",
           "description": "Total number of vaccine doses administered.",
@@ -751,6 +763,18 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinationsBivalentDoseRatio": {
+          "title": "Vaccinationsbivalentdoseratio",
+          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -783,7 +807,7 @@
       "type": "object",
       "properties": {
         "overall": {
-          "description": "Overall risk level for region .",
+          "description": "Overall risk level for region.",
           "allOf": [
             {
               "$ref": "#/definitions/RiskLevel"
@@ -830,7 +854,7 @@
       "type": "object",
       "properties": {
         "cdcCommunityLevel": {
-          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCDC Community level for county, as provided by the CDC.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"
@@ -838,7 +862,7 @@
           ]
         },
         "canCommunityLevel": {
-          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpretted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated on a daily basis using CAN's data\nsources and is available for states, counties, and metros.  The other is\ncalled cdcCommunityLevel and is the raw Community Level published by the\nCDC. It is only available for counties, and updates on a weekly basis.\n",
+          "description": "\nCommunity level for region, calculated using the CDC definition but with CAN\ndata sources.\n\nPossible values:\n    - 0: Low\n    - 1: Medium\n    - 2: High\n\nSee https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html\nfor details about how the Community Level is calculated and should be\ninterpreted.\n\nNote that we provide two versions of the Community Level. One is called\ncanCommunityLevel which is calculated using CAN's data sources and is\navailable for states, counties, and metros. It is updated daily though\ndepends on hospital data which may only update weekly for counties. The\nother is called cdcCommunityLevel and is the raw Community Level published\nby the CDC. It is only available for counties and is updated on a weekly\nbasis.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CommunityLevel"

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -109,7 +109,7 @@
     },
     "hsa": {
       "title": "Hsa",
-      "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+      "description": "3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
       "anyOf": [
         {
           "type": "string"
@@ -121,7 +121,7 @@
     },
     "hsaName": {
       "title": "Hsaname",
-      "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+      "description": "Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
       "anyOf": [
         {
           "type": "string"
@@ -133,7 +133,7 @@
     },
     "hsaPopulation": {
       "title": "Hsapopulation",
-      "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md",
+      "description": "Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md",
       "exclusiveMinimum": 0,
       "anyOf": [
         {
@@ -421,7 +421,7 @@
         },
         "hsaHospitalBeds": {
           "title": "Hsahospitalbeds",
-          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
+          "description": "\nInformation about acute bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed acute bed capacity.\n * currentUsageTotal - Total number of acute beds currently in use\n * currentUsageCovid - Number of acute beds currently in use by COVID patients.\n * weeklyCovidAdmissions - Number of COVID patients admitted in the past week.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilizationWithAdmissions"
@@ -439,7 +439,7 @@
         },
         "hsaIcuBeds": {
           "title": "Hsaicubeds",
-          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
+          "description": "\nInformation about ICU bed utilization details aggregated for the county's corresponding\nHealth Service Area (HSA). For CBSA, state, and country regions these fields are omitted.\nFor For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md\"\n\nFields:\n * capacity - Current staffed ICU bed capacity.\n * currentUsageTotal - Total number of ICU beds currently in use\n * currentUsageCovid - Number of ICU beds currently in use by COVID patients.\n",
           "allOf": [
             {
               "$ref": "#/definitions/HospitalResourceUtilization"
@@ -706,7 +706,7 @@
         },
         "bedsWithCovidPatientsRatio": {
           "title": "Bedswithcovidpatientsratio",
-          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -718,7 +718,7 @@
         },
         "weeklyCovidAdmissionsPer100k": {
           "title": "Weeklycovidadmissionsper100K",
-          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.",
+          "description": "Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas",
           "anyOf": [
             {
               "type": "number"
@@ -766,7 +766,7 @@
         },
         "vaccinationsBivalentDoseRatio": {
           "title": "Vaccinationsbivalentdoseratio",
-          "description": "Ratio of population have received a bivalent vaccine dose.",
+          "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {
               "type": "number"

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -518,8 +518,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDose": {
-          "title": "Vaccinationsbivalentdose",
+        "vaccinationsFall2022BivalentBooster": {
+          "title": "Vaccinationsfall2022Bivalentbooster",
           "description": "Number of individuals who have received a bivalent vaccine dose.",
           "anyOf": [
             {
@@ -764,8 +764,8 @@
             }
           ]
         },
-        "vaccinationsBivalentDoseRatio": {
-          "title": "Vaccinationsbivalentdoseratio",
+        "vaccinationsFall2022BivalentBoosterRatio": {
+          "title": "Vaccinationsfall2022Bivalentboosterratio",
           "description": "Ratio of population that have received a bivalent vaccine dose.",
           "anyOf": [
             {

--- a/api/schemas_v2/RiskLevelTimeseriesRow.json
+++ b/api/schemas_v2/RiskLevelTimeseriesRow.json
@@ -4,7 +4,7 @@
   "type": "object",
   "properties": {
     "overall": {
-      "description": "Overall risk level for region .",
+      "description": "Overall risk level for region.",
       "allOf": [
         {
           "$ref": "#/definitions/RiskLevel"

--- a/api/schemas_v2/RiskLevelsRow.json
+++ b/api/schemas_v2/RiskLevelsRow.json
@@ -4,7 +4,7 @@
   "type": "object",
   "properties": {
     "overall": {
-      "description": "Overall risk level for region .",
+      "description": "Overall risk level for region.",
       "allOf": [
         {
           "$ref": "#/definitions/RiskLevel"

--- a/datapublic/common_fields.py
+++ b/datapublic/common_fields.py
@@ -204,6 +204,8 @@ class CommonFields(GetByValueMixin, ValueAsStrMixin, FieldName, enum.Enum):
     VACCINATIONS_INITIATED_PCT = "vaccinations_initiated_pct", FieldGroup.VACCINES
     VACCINATIONS_ADDITIONAL_DOSE = "vaccinations_additional_dose", FieldGroup.VACCINES
     VACCINATIONS_ADDITIONAL_DOSE_PCT = "vaccinations_additional_dose_pct", FieldGroup.VACCINES
+    VACCINATIONS_BIVALENT_DOSE = "vaccinations_bivalent_dose", FieldGroup.VACCINES
+    VACCINATIONS_BIVALENT_DOSE_PCT = "vaccinations_bivalent_dose_pct", FieldGroup.VACCINES
     VACCINATIONS_COMPLETED = "vaccinations_completed", FieldGroup.VACCINES
     VACCINATIONS_COMPLETED_PCT = "vaccinations_completed_pct", FieldGroup.VACCINES
 

--- a/datapublic/common_fields.py
+++ b/datapublic/common_fields.py
@@ -204,7 +204,10 @@ class CommonFields(GetByValueMixin, ValueAsStrMixin, FieldName, enum.Enum):
     VACCINATIONS_INITIATED_PCT = "vaccinations_initiated_pct", FieldGroup.VACCINES
     VACCINATIONS_ADDITIONAL_DOSE = "vaccinations_additional_dose", FieldGroup.VACCINES
     VACCINATIONS_ADDITIONAL_DOSE_PCT = "vaccinations_additional_dose_pct", FieldGroup.VACCINES
-    VACCINATIONS_BIVALENT_DOSE = "vaccinations_bivalent_dose", FieldGroup.VACCINES
+    VACCINATIONS_2022_FALL_BIVALENT_DOSE = (
+        "vaccinations_2022_fall_bivalent_dose",
+        FieldGroup.VACCINES,
+    )
     VACCINATIONS_BIVALENT_DOSE_PCT = "vaccinations_bivalent_dose_pct", FieldGroup.VACCINES
     VACCINATIONS_COMPLETED = "vaccinations_completed", FieldGroup.VACCINES
     VACCINATIONS_COMPLETED_PCT = "vaccinations_completed_pct", FieldGroup.VACCINES

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -120,7 +120,9 @@ def _build_actuals(actual_data: dict, distributions_by_field: Optional[Dict] = N
         vaccinationsInitiated=vaccinations_initiated,
         vaccinationsCompleted=actual_data.get(CommonFields.VACCINATIONS_COMPLETED),
         vaccinationsAdditionalDose=actual_data.get(CommonFields.VACCINATIONS_ADDITIONAL_DOSE),
-        vaccinationsBivalentDose=actual_data.get(CommonFields.VACCINATIONS_BIVALENT_DOSE),
+        vaccinationsFall2022BivalentBooster=actual_data.get(
+            CommonFields.VACCINATIONS_2022_FALL_BIVALENT_DOSE
+        ),
         vaccinesAdministered=actual_data.get(CommonFields.VACCINES_ADMINISTERED),
         vaccinesAdministeredDemographics=vaccines_administered_demographics,
         vaccinationsInitiatedDemographics=vaccines_initiated_demographics,
@@ -185,7 +187,7 @@ ACTUALS_NAME_TO_COMMON_FIELD = {
     "vaccinationsInitiated": CommonFields.VACCINATIONS_INITIATED,
     "vaccinationsCompleted": CommonFields.VACCINATIONS_COMPLETED,
     "vaccinationsAdditionalDose": CommonFields.VACCINATIONS_ADDITIONAL_DOSE,
-    "vaccinationsBivalentDose": CommonFields.VACCINATIONS_BIVALENT_DOSE,
+    "vaccinationsFall2022BivalentBooster": CommonFields.VACCINATIONS_2022_FALL_BIVALENT_DOSE,
 }
 
 
@@ -200,7 +202,7 @@ METRICS_NAME_TO_COMMON_FIELD = {
     "vaccinationsInitiatedRatio": CommonFields.VACCINATIONS_INITIATED_PCT,
     "vaccinationsCompletedRatio": CommonFields.VACCINATIONS_COMPLETED_PCT,
     "vaccinationsAdditionalDoseRatio": CommonFields.VACCINATIONS_ADDITIONAL_DOSE_PCT,
-    "vaccinationsBivalentDoseRatio": CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT,
+    "vaccinationsFall2022BivalentBoosterRatio": CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT,
     "icuCapacityRatio": CommonFields.CURRENT_ICU,
     "bedsWithCovidPatientsRatio": CommonFields.CURRENT_HOSPITALIZED,
     "weeklyCovidAdmissionsPer100k": CommonFields.WEEKLY_NEW_HOSPITAL_ADMISSIONS_COVID,
@@ -317,7 +319,7 @@ def build_region_timeseries(
             del actual["vaccinationsAdditionalDose"]
 
         if row[CommonFields.DATE] < USA_BIVALENT_VACCINATION_START_DATE:
-            del actual["vaccinationsBivalentDose"]
+            del actual["vaccinationsFall2022BivalentBooster"]
 
         timeseries_row = ActualsTimeseriesRow(**actual, date=row[CommonFields.DATE])
         actuals_timeseries.append(timeseries_row)
@@ -331,7 +333,7 @@ def build_region_timeseries(
             del metric_row["vaccinationsCompletedRatio"]
             del metric_row["vaccinationsAdditionalDoseRatio"]
         if metric_row[CommonFields.DATE] < USA_BIVALENT_VACCINATION_START_DATE:
-            del metric_row["vaccinationsBivalentDoseRatio"]
+            del metric_row["vaccinationsFall2022BivalentBoosterRatio"]
         metrics_rows.append(MetricsTimeseriesRow(**metric_row))
 
     risk_level_rows = [

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -40,6 +40,7 @@ METRIC_MULTIPLE_SOURCE_URLS_MESSAGE = "More than one source_url for a field"
 METRIC_MULTIPLE_SOURCE_TYPES_MESSAGE = "More than one provenance for a field"
 
 USA_VACCINATION_START_DATE = datetime(2020, 12, 14)
+USA_BIVALENT_VACCINATION_START_DATE = datetime(2022, 9, 1)
 
 
 def _build_distributions(
@@ -119,6 +120,7 @@ def _build_actuals(actual_data: dict, distributions_by_field: Optional[Dict] = N
         vaccinationsInitiated=vaccinations_initiated,
         vaccinationsCompleted=actual_data.get(CommonFields.VACCINATIONS_COMPLETED),
         vaccinationsAdditionalDose=actual_data.get(CommonFields.VACCINATIONS_ADDITIONAL_DOSE),
+        vaccinationsBivalentDose=actual_data.get(CommonFields.VACCINATIONS_BIVALENT_DOSE),
         vaccinesAdministered=actual_data.get(CommonFields.VACCINES_ADMINISTERED),
         vaccinesAdministeredDemographics=vaccines_administered_demographics,
         vaccinationsInitiatedDemographics=vaccines_initiated_demographics,
@@ -183,6 +185,7 @@ ACTUALS_NAME_TO_COMMON_FIELD = {
     "vaccinationsInitiated": CommonFields.VACCINATIONS_INITIATED,
     "vaccinationsCompleted": CommonFields.VACCINATIONS_COMPLETED,
     "vaccinationsAdditionalDose": CommonFields.VACCINATIONS_ADDITIONAL_DOSE,
+    "vaccinationsBivalentDose": CommonFields.VACCINATIONS_BIVALENT_DOSE,
 }
 
 
@@ -197,6 +200,7 @@ METRICS_NAME_TO_COMMON_FIELD = {
     "vaccinationsInitiatedRatio": CommonFields.VACCINATIONS_INITIATED_PCT,
     "vaccinationsCompletedRatio": CommonFields.VACCINATIONS_COMPLETED_PCT,
     "vaccinationsAdditionalDoseRatio": CommonFields.VACCINATIONS_ADDITIONAL_DOSE_PCT,
+    "vaccinationsBivalentDoseRatio": CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT,
     "icuCapacityRatio": CommonFields.CURRENT_ICU,
     "bedsWithCovidPatientsRatio": CommonFields.CURRENT_HOSPITALIZED,
     "weeklyCovidAdmissionsPer100k": CommonFields.WEEKLY_NEW_HOSPITAL_ADMISSIONS_COVID,
@@ -312,6 +316,9 @@ def build_region_timeseries(
             del actual["vaccinationsCompleted"]
             del actual["vaccinationsAdditionalDose"]
 
+    if row[CommonFields.DATE] < USA_BIVALENT_VACCINATION_START_DATE:
+        del actual["vaccinationsBivalentDose"]
+
         timeseries_row = ActualsTimeseriesRow(**actual, date=row[CommonFields.DATE])
         actuals_timeseries.append(timeseries_row)
 
@@ -323,6 +330,8 @@ def build_region_timeseries(
             del metric_row["vaccinationsInitiatedRatio"]
             del metric_row["vaccinationsCompletedRatio"]
             del metric_row["vaccinationsAdditionalDoseRatio"]
+        if metric_row[CommonFields.DATE] < USA_BIVALENT_VACCINATION_START_DATE:
+            del metric_row["vaccinationsBivalentDoseRatio"]
         metrics_rows.append(MetricsTimeseriesRow(**metric_row))
 
     risk_level_rows = [

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -316,8 +316,8 @@ def build_region_timeseries(
             del actual["vaccinationsCompleted"]
             del actual["vaccinationsAdditionalDose"]
 
-    if row[CommonFields.DATE] < USA_BIVALENT_VACCINATION_START_DATE:
-        del actual["vaccinationsBivalentDose"]
+        if row[CommonFields.DATE] < USA_BIVALENT_VACCINATION_START_DATE:
+            del actual["vaccinationsBivalentDose"]
 
         timeseries_row = ActualsTimeseriesRow(**actual, date=row[CommonFields.DATE])
         actuals_timeseries.append(timeseries_row)

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -330,7 +330,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
         CDCVaccinesStatesAndNationDataset,
         CDCNewVaccinesCompletedBoosterCountiesWithoutExceptions,
     ],
-    CommonFields.VACCINATIONS_BIVALENT_DOSE: [
+    CommonFields.VACCINATIONS_2022_FALL_BIVALENT_DOSE: [
         CDCVaccinesStatesAndNationDataset,
         CDCNewVaccinesCompletedBoosterCountiesWithoutExceptions,
     ],

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -330,6 +330,10 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
         CDCVaccinesStatesAndNationDataset,
         CDCNewVaccinesCompletedBoosterCountiesWithoutExceptions,
     ],
+    CommonFields.VACCINATIONS_BIVALENT_DOSE: [
+        CDCVaccinesStatesAndNationDataset,
+        CDCNewVaccinesCompletedBoosterCountiesWithoutExceptions,
+    ],
     CommonFields.VACCINATIONS_INITIATED_PCT: [
         CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,

--- a/libs/datasets/dataset_updater.py
+++ b/libs/datasets/dataset_updater.py
@@ -167,6 +167,7 @@ class DatasetUpdater:
                 CommonFields.VACCINATIONS_COMPLETED,
                 CommonFields.VACCINATIONS_INITIATED,
                 CommonFields.VACCINATIONS_ADDITIONAL_DOSE,
+                CommonFields.VACCINATIONS_BIVALENT_DOSE,
             ],
         )
         multiregion_dataset = vaccine_backfills.estimate_initiated_from_state_ratio(

--- a/libs/datasets/dataset_updater.py
+++ b/libs/datasets/dataset_updater.py
@@ -167,7 +167,7 @@ class DatasetUpdater:
                 CommonFields.VACCINATIONS_COMPLETED,
                 CommonFields.VACCINATIONS_INITIATED,
                 CommonFields.VACCINATIONS_ADDITIONAL_DOSE,
-                CommonFields.VACCINATIONS_BIVALENT_DOSE,
+                CommonFields.VACCINATIONS_2022_FALL_BIVALENT_DOSE,
             ],
         )
         multiregion_dataset = vaccine_backfills.estimate_initiated_from_state_ratio(

--- a/libs/datasets/sources/cdc_new_vaccine_counties_dataset.py
+++ b/libs/datasets/sources/cdc_new_vaccine_counties_dataset.py
@@ -53,4 +53,11 @@ class CDCNewVaccinesCountiesDataset(data_source.CanScraperBase):
             provider="cdc2",
             common_field=CommonFields.VACCINATIONS_ADDITIONAL_DOSE,
         ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_additional_dose",  # TODO: USE BIVALENT DATA ONCE IT'S IN THE PARQUET
+            measurement="cumulative",
+            unit="people",
+            provider="cdc2",
+            common_field=CommonFields.VACCINATIONS_BIVALENT_DOSE,
+        ),
     ]

--- a/libs/datasets/sources/cdc_new_vaccine_counties_dataset.py
+++ b/libs/datasets/sources/cdc_new_vaccine_counties_dataset.py
@@ -8,6 +8,7 @@ class CDCNewVaccinesCountiesDataset(data_source.CanScraperBase):
     1st dose data and historical timeseries data. This is surfaced by the
     scrapers as provider=cdc2 and we now prefer it over the old data source."""
 
+    # This data source is used to pull in county-level vaccine data from the CDC.
     SOURCE_TYPE = "CDCNewVaccinesCountiesDataset"
 
     VARIABLES = [

--- a/libs/datasets/sources/cdc_new_vaccine_counties_dataset.py
+++ b/libs/datasets/sources/cdc_new_vaccine_counties_dataset.py
@@ -59,6 +59,6 @@ class CDCNewVaccinesCountiesDataset(data_source.CanScraperBase):
             measurement="cumulative",
             unit="people",
             provider="cdc2",
-            common_field=CommonFields.VACCINATIONS_BIVALENT_DOSE,
+            common_field=CommonFields.VACCINATIONS_2022_FALL_BIVALENT_DOSE,
         ),
     ]

--- a/libs/datasets/sources/cdc_new_vaccine_counties_dataset.py
+++ b/libs/datasets/sources/cdc_new_vaccine_counties_dataset.py
@@ -54,7 +54,7 @@ class CDCNewVaccinesCountiesDataset(data_source.CanScraperBase):
             common_field=CommonFields.VACCINATIONS_ADDITIONAL_DOSE,
         ),
         ccd_helpers.ScraperVariable(
-            variable_name="total_vaccine_additional_dose",  # TODO: USE BIVALENT DATA ONCE IT'S IN THE PARQUET
+            variable_name="total_vaccine_bivalent_dose",
             measurement="cumulative",
             unit="people",
             provider="cdc2",

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -4,6 +4,7 @@ from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 
 class CDCVaccinesDataset(data_source.CanScraperBase):
+    # This data source is used to pull in state-level vaccine data from the CDC.
     SOURCE_TYPE = "CDCVaccine"
 
     VARIABLES = [

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -50,7 +50,7 @@ class CDCVaccinesDataset(data_source.CanScraperBase):
             common_field=CommonFields.VACCINATIONS_ADDITIONAL_DOSE,
         ),
         ccd_helpers.ScraperVariable(
-            variable_name="total_vaccine_additional_dose",  # TODO: USE BIVALENT DATA ONCE IT'S IN THE PARQUET
+            variable_name="total_vaccine_bivalent_dose",
             measurement="cumulative",
             unit="people",
             provider="cdc",

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -55,6 +55,6 @@ class CDCVaccinesDataset(data_source.CanScraperBase):
             measurement="cumulative",
             unit="people",
             provider="cdc",
-            common_field=CommonFields.VACCINATIONS_BIVALENT_DOSE,
+            common_field=CommonFields.VACCINATIONS_2022_FALL_BIVALENT_DOSE,
         ),
     ]

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -49,4 +49,11 @@ class CDCVaccinesDataset(data_source.CanScraperBase):
             provider="cdc",
             common_field=CommonFields.VACCINATIONS_ADDITIONAL_DOSE,
         ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_additional_dose",  # TODO: USE BIVALENT DATA ONCE IT'S IN THE PARQUET
+            measurement="cumulative",
+            unit="people",
+            provider="cdc",
+            common_field=CommonFields.VACCINATIONS_BIVALENT_DOSE,
+        ),
     ]

--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -33,7 +33,7 @@ def derive_vaccine_pct(
         CommonFields.VACCINATIONS_INITIATED: CommonFields.VACCINATIONS_INITIATED_PCT,
         CommonFields.VACCINATIONS_COMPLETED: CommonFields.VACCINATIONS_COMPLETED_PCT,
         CommonFields.VACCINATIONS_ADDITIONAL_DOSE: CommonFields.VACCINATIONS_ADDITIONAL_DOSE_PCT,
-        CommonFields.VACCINATIONS_BIVALENT_DOSE: CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT,
+        CommonFields.VACCINATIONS_2022_FALL_BIVALENT_DOSE: CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT,
     }
 
     ts_in_all = ds_in.timeseries_bucketed_wide_dates

--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -33,6 +33,7 @@ def derive_vaccine_pct(
         CommonFields.VACCINATIONS_INITIATED: CommonFields.VACCINATIONS_INITIATED_PCT,
         CommonFields.VACCINATIONS_COMPLETED: CommonFields.VACCINATIONS_COMPLETED_PCT,
         CommonFields.VACCINATIONS_ADDITIONAL_DOSE: CommonFields.VACCINATIONS_ADDITIONAL_DOSE_PCT,
+        CommonFields.VACCINATIONS_BIVALENT_DOSE: CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT,
     }
 
     ts_in_all = ds_in.timeseries_bucketed_wide_dates

--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -49,7 +49,7 @@ class MetricsFields(common_fields.ValueAsStrMixin, str, enum.Enum):
     VACCINATIONS_INITIATED_RATIO = "vaccinationsInitiatedRatio"
     VACCINATIONS_COMPLETED_RATIO = "vaccinationsCompletedRatio"
     VACCINATIONS_ADDITIONAL_DOSE_RATIO = "vaccinationsAdditionalDoseRatio"
-    VACCINATIONS_BIVALENT_DOSE_RATIO = "vaccinationsBivalentDoseRatio"
+    VACCINATIONS_BIVALENT_DOSE_RATIO = "vaccinationsFall2022BivalentBoosterRatio"
 
 
 # These precisions should be inline with

--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -49,6 +49,7 @@ class MetricsFields(common_fields.ValueAsStrMixin, str, enum.Enum):
     VACCINATIONS_INITIATED_RATIO = "vaccinationsInitiatedRatio"
     VACCINATIONS_COMPLETED_RATIO = "vaccinationsCompletedRatio"
     VACCINATIONS_ADDITIONAL_DOSE_RATIO = "vaccinationsAdditionalDoseRatio"
+    VACCINATIONS_BIVALENT_DOSE_RATIO = "vaccinationsBivalentDoseRatio"
 
 
 # These precisions should be inline with
@@ -70,6 +71,7 @@ METRIC_ROUNDING_PRECISION = {
     MetricsFields.VACCINATIONS_INITIATED_RATIO: 3,
     MetricsFields.VACCINATIONS_COMPLETED_RATIO: 3,
     MetricsFields.VACCINATIONS_ADDITIONAL_DOSE_RATIO: 3,
+    MetricsFields.VACCINATIONS_BIVALENT_DOSE_RATIO: 3,
 }
 
 
@@ -134,6 +136,13 @@ def calculate_metrics_for_timeseries(
         / 100.0
     )
 
+    vaccines_bivalent_dose_ratio = (
+        common_df.get_timeseries(
+            timeseries.date_indexed, CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT, EMPTY_TS
+        )
+        / 100.0
+    )
+
     top_level_metrics_data = {
         CommonFields.FIPS: fips,
         MetricsFields.CASE_DENSITY_RATIO: case_density,
@@ -148,6 +157,7 @@ def calculate_metrics_for_timeseries(
         MetricsFields.VACCINATIONS_INITIATED_RATIO: vaccines_initiated_ratio,
         MetricsFields.VACCINATIONS_COMPLETED_RATIO: vaccines_completed_ratio,
         MetricsFields.VACCINATIONS_ADDITIONAL_DOSE_RATIO: vaccines_additional_dose_ratio,
+        MetricsFields.VACCINATIONS_BIVALENT_DOSE_RATIO: vaccines_bivalent_dose_ratio,
     }
     metrics = pd.DataFrame(top_level_metrics_data)
     metrics = metrics.round(METRIC_ROUNDING_PRECISION)

--- a/libs/pipelines/csv_column_ordering.py
+++ b/libs/pipelines/csv_column_ordering.py
@@ -85,6 +85,8 @@ SUMMARY_ORDER = [
     "metrics.weeklyCovidAdmissionsPer100k",
     "communityLevels.cdcCommunityLevel",
     "communityLevels.canCommunityLevel",
+    "actuals.vaccinationsBivalentDose",
+    "metrics.vaccinationsBivalentDoseRatio",
 ]
 
 # Due to an inconsistency with how we previously were generating column names,
@@ -167,6 +169,8 @@ SUMMARY_ORDER_NO_HEADROOM_DETAILS = [
     "metrics.weeklyCovidAdmissionsPer100k",
     "communityLevels.cdcCommunityLevel",
     "communityLevels.canCommunityLevel",
+    "actuals.vaccinationsBivalentDose",
+    "metrics.vaccinationsBivalentDoseRatio",
 ]
 
 
@@ -236,4 +240,6 @@ TIMESERIES_ORDER = [
     "metrics.weeklyCovidAdmissionsPer100k",
     "communityLevels.cdcCommunityLevel",
     "communityLevels.canCommunityLevel",
+    "actuals.vaccinationsBivalentDose",
+    "metrics.vaccinationsBivalentDoseRatio",
 ]

--- a/libs/pipelines/csv_column_ordering.py
+++ b/libs/pipelines/csv_column_ordering.py
@@ -85,8 +85,8 @@ SUMMARY_ORDER = [
     "metrics.weeklyCovidAdmissionsPer100k",
     "communityLevels.cdcCommunityLevel",
     "communityLevels.canCommunityLevel",
-    "actuals.vaccinationsBivalentDose",
-    "metrics.vaccinationsBivalentDoseRatio",
+    "actuals.vaccinationsFall2022BivalentBooster",
+    "metrics.vaccinationsFall2022BivalentBoosterRatio",
 ]
 
 # Due to an inconsistency with how we previously were generating column names,
@@ -169,8 +169,8 @@ SUMMARY_ORDER_NO_HEADROOM_DETAILS = [
     "metrics.weeklyCovidAdmissionsPer100k",
     "communityLevels.cdcCommunityLevel",
     "communityLevels.canCommunityLevel",
-    "actuals.vaccinationsBivalentDose",
-    "metrics.vaccinationsBivalentDoseRatio",
+    "actuals.vaccinationsFall2022BivalentBooster",
+    "metrics.vaccinationsFall2022BivalentBoosterRatio",
 ]
 
 
@@ -240,6 +240,6 @@ TIMESERIES_ORDER = [
     "metrics.weeklyCovidAdmissionsPer100k",
     "communityLevels.cdcCommunityLevel",
     "communityLevels.canCommunityLevel",
-    "actuals.vaccinationsBivalentDose",
-    "metrics.vaccinationsBivalentDoseRatio",
+    "actuals.vaccinationsFall2022BivalentBooster",
+    "metrics.vaccinationsFall2022BivalentBoosterRatio",
 ]

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -23,7 +23,7 @@ def test_derive_vaccine_pct():
         ),
         CommonFields.VACCINATIONS_COMPLETED: [None, 1_000],
         CommonFields.VACCINATIONS_ADDITIONAL_DOSE: [1_000, 5_000],
-        CommonFields.VACCINATIONS_BIVALENT_DOSE: [1_000, 5_000],
+        CommonFields.VACCINATIONS_2022_FALL_BIVALENT_DOSE: [1_000, 5_000],
         CommonFields.CASES: TimeseriesLiteral([1, 2], provenance=["caseprov"]),
     }
 

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -23,7 +23,7 @@ def test_derive_vaccine_pct():
         ),
         CommonFields.VACCINATIONS_COMPLETED: [None, 1_000],
         CommonFields.VACCINATIONS_ADDITIONAL_DOSE: [1_000, 5_000],
-        CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT: [1_000, 5_000],
+        CommonFields.VACCINATIONS_BIVALENT_DOSE: [1_000, 5_000],
         CommonFields.CASES: TimeseriesLiteral([1, 2], provenance=["caseprov"]),
     }
 
@@ -54,6 +54,7 @@ def test_derive_vaccine_pct():
     )
 
     ds_out = vaccine_backfills.derive_vaccine_pct(ds_in)
+    print(ds_out.timeseries[["vaccinations_bivalent_dose"]])
 
     ds_expected = test_helpers.build_dataset(
         {
@@ -69,6 +70,7 @@ def test_derive_vaccine_pct():
         },
         static_by_region_then_field_name=static_data_map,
     )
+    print(ds_expected.timeseries[["vaccinations_bivalent_dose"]])
     test_helpers.assert_dataset_like(ds_out, ds_expected)
 
 

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -23,6 +23,7 @@ def test_derive_vaccine_pct():
         ),
         CommonFields.VACCINATIONS_COMPLETED: [None, 1_000],
         CommonFields.VACCINATIONS_ADDITIONAL_DOSE: [1_000, 5_000],
+        CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT: [1_000, 5_000],
         CommonFields.CASES: TimeseriesLiteral([1, 2], provenance=["caseprov"]),
     }
 
@@ -61,6 +62,7 @@ def test_derive_vaccine_pct():
                 CommonFields.VACCINATIONS_INITIATED_PCT: [1, 2],
                 CommonFields.VACCINATIONS_COMPLETED_PCT: [None, 1],
                 CommonFields.VACCINATIONS_ADDITIONAL_DOSE_PCT: [1, 5],
+                CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT: [1, 5],
             },
             region_ma: {**ma_timeseries_in, CommonFields.VACCINATIONS_INITIATED_PCT: [94, 95],},
             region_sf: {CommonFields.VACCINATIONS_COMPLETED_PCT: [10, 95],},

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -54,7 +54,6 @@ def test_derive_vaccine_pct():
     )
 
     ds_out = vaccine_backfills.derive_vaccine_pct(ds_in)
-    print(ds_out.timeseries[["vaccinations_bivalent_dose"]])
 
     ds_expected = test_helpers.build_dataset(
         {
@@ -70,7 +69,6 @@ def test_derive_vaccine_pct():
         },
         static_by_region_then_field_name=static_data_map,
     )
-    print(ds_expected.timeseries[["vaccinations_bivalent_dose"]])
     test_helpers.assert_dataset_like(ds_out, ds_expected)
 
 

--- a/tests/libs/metrics/top_level_metrics_test.py
+++ b/tests/libs/metrics/top_level_metrics_test.py
@@ -199,7 +199,7 @@ def test_top_level_metrics_basic():
         vaccinationsInitiatedRatio=[0.01, 0.02, None, 0.03],
         vaccinationsCompletedRatio=[0.001, 0.002, None, 0.003],
         vaccinationsAdditionalDoseRatio=[0.001, 0.002, None, 0.003],
-        vaccinationsBivalentDoseRatio=[0.001, 0.002, None, 0.003],
+        vaccinationsFall2022BivalentBoosterRatio=[0.001, 0.002, None, 0.003],
         bedsWithCovidPatientsRatio=[0.1, 0.1, 0.05, 0.05],
         weeklyCovidAdmissionsPer100k=[1.0, 1.0, 2.0, 2.0],
     )
@@ -246,7 +246,7 @@ def test_top_level_metrics_rounding():
         vaccinationsInitiatedRatio=[0.333, 0.667, 1],
         vaccinationsCompletedRatio=[0.333, 0.667, 1],
         vaccinationsAdditionalDoseRatio=[0.333, 0.667, 1],
-        vaccinationsBivalentDoseRatio=[0.333, 0.667, 1],
+        vaccinationsFall2022BivalentBoosterRatio=[0.333, 0.667, 1],
         bedsWithCovidPatientsRatio=[0.1, 0.1, 0.086],
         weeklyCovidAdmissionsPer100k=[2.0, 3.0, 4.0],
     )

--- a/tests/libs/metrics/top_level_metrics_test.py
+++ b/tests/libs/metrics/top_level_metrics_test.py
@@ -198,6 +198,7 @@ def test_top_level_metrics_basic():
         vaccinationsInitiatedRatio=[0.01, 0.02, None, 0.03],
         vaccinationsCompletedRatio=[0.001, 0.002, None, 0.003],
         vaccinationsAdditionalDoseRatio=[0.001, 0.002, None, 0.003],
+        vaccinationsBivalentDoseRatio=[0.001, 0.002, None, 0.003],
         bedsWithCovidPatientsRatio=[0.1, 0.1, 0.05, 0.05],
         weeklyCovidAdmissionsPer100k=[1.0, 1.0, 2.0, 2.0],
     )
@@ -219,6 +220,7 @@ def test_top_level_metrics_rounding():
         CommonFields.VACCINATIONS_INITIATED_PCT: [33.3333, 66.666, 100],
         CommonFields.VACCINATIONS_COMPLETED_PCT: [33.3333, 66.6666, 100],
         CommonFields.VACCINATIONS_ADDITIONAL_DOSE_PCT: [33.3333, 66.6666, 100],
+        CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT: [33.3333, 66.6666, 100],
     }
     latest = {
         CommonFields.POPULATION: 100_000,
@@ -243,6 +245,7 @@ def test_top_level_metrics_rounding():
         vaccinationsInitiatedRatio=[0.333, 0.667, 1],
         vaccinationsCompletedRatio=[0.333, 0.667, 1],
         vaccinationsAdditionalDoseRatio=[0.333, 0.667, 1],
+        vaccinationsBivalentDoseRatio=[0.333, 0.667, 1],
         bedsWithCovidPatientsRatio=[0.1, 0.1, 0.086],
         weeklyCovidAdmissionsPer100k=[2.0, 3.0, 4.0],
     )

--- a/tests/libs/metrics/top_level_metrics_test.py
+++ b/tests/libs/metrics/top_level_metrics_test.py
@@ -171,6 +171,7 @@ def test_top_level_metrics_basic():
         CommonFields.VACCINATIONS_INITIATED_PCT: [1, 2, None, 3],
         CommonFields.VACCINATIONS_COMPLETED_PCT: [0.1, 0.2, None, 0.3],
         CommonFields.VACCINATIONS_ADDITIONAL_DOSE_PCT: [0.1, 0.2, None, 0.3],
+        CommonFields.VACCINATIONS_BIVALENT_DOSE_PCT: [0.1, 0.2, None, 0.3],
         CommonFields.STAFFED_BEDS_HSA: [10, 20, 60, 80],
         CommonFields.CURRENT_HOSPITALIZED_HSA: [1, 2, 3, 4],
         CommonFields.WEEKLY_NEW_HOSPITAL_ADMISSIONS_COVID_HSA: [1, 1, 2, 2],


### PR DESCRIPTION
Adds bivalent CDC-sourced vaccine data to the API. [Example output of MA here](https://gist.githubusercontent.com/smcclure17/bbb6a22b359fe90030bf87b8d4cb0c8f/raw/9b0470ca5c5e7ad2b5cc1e0ec77d239d2403489b/MA.timeseries.json)