### PR TITLE
Point frontend snapshot trigger to renamed repository

### DIFF
--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -53,7 +53,7 @@ class MetricsFields(common_fields.ValueAsStrMixin, str, enum.Enum):
 
 
 # These precisions should be inline with
-# https://github.com/act-now-coalition/covid-projections/blob/c076f39f54dcf6ca3f20fbb67839c37bb8b0f5bf/src/common/metric.tsx#L90
+# https://github.com/act-now-coalition/covid-act-now-website/blob/c076f39f54dcf6ca3f20fbb67839c37bb8b0f5bf/src/common/metric.tsx#L90
 # but note that percentages (ICU_*, TEST_POSITIVITY, VACCINATIONS_*) need an
 # additional 2 digits of precisions since they will be converted from ratio
 # (0.xyz) to percentage (XY.Z%).

--- a/libs/series_utils.py
+++ b/libs/series_utils.py
@@ -17,7 +17,7 @@ def smooth_with_rolling_average(
     https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.rolling.html
 
     Port of Projections.ts:
-    https://github.com/act-now-coalition/covid-projections/blob/master/src/common/models/Projection.ts#L715
+    https://github.com/act-now-coalition/covid-act-now-website/blob/master/src/common/models/Projection.ts#L715
 
     Args:
         series: Series with datetime index to smooth.

--- a/scripts/can_raw_location_page_urls.py
+++ b/scripts/can_raw_location_page_urls.py
@@ -11,7 +11,7 @@ from libs.datasets.dataset_utils import DATA_DIRECTORY
 # NOTE(sean) 1/18/21: This file does not exist anymore, so this script is not functional.
 # This script was used to generate the location page URLs used in the API.
 DATASET_URL = (
-    "https://github.com/act-now-coalition/covid-projections/raw/develop/src/components/"
+    "https://github.com/act-now-coalition/covid-act-now-website/raw/develop/src/components/"
     "MapSelectors/datasets/us_states_dataset_01_02_2020.json"
 )
 CSV_PATH = DATA_DIRECTORY / "misc" / "can_location_page_urls.csv"

--- a/services/data-pipeline-dashboard/Makefile
+++ b/services/data-pipeline-dashboard/Makefile
@@ -1,4 +1,4 @@
-# Inspired by https://github.com/covid-projections/can-scrapers/blob/main/services/prefect/Makefile
+# Inspired by https://github.com/act-now-coalition/can-scrapers/blob/main/services/prefect/Makefile
 
 sync_nginx:
 	sudo cp ./nginx.conf /etc/nginx/sites-available/data-pipeline-dashboard

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="pyseir",
     version="0.2",
     description=(""),
-    url="https://github.com/covid-projections/covid-data-model/",
+    url="https://github.com/act-now-coalition/covid-data-model/",
     author="covidactnow.com",
     install_requires=["Click",],
     entry_points="""

--- a/tools/maybe-trigger-web-snapshot-update.sh
+++ b/tools/maybe-trigger-web-snapshot-update.sh
@@ -2,7 +2,7 @@
 # maybe-trigger-web-snapshot-update.sh
 #
 # Helper script called at the end of the deploy_api.yml workflow to potentially
-# trigger the update-snapshot.yml workflow in the covid-projections repo to
+# trigger the update-snapshot.yml workflow in the covid-act-now-website repo to
 # update to the newly generated snapshot.
 
 set -o nounset
@@ -10,7 +10,7 @@ set -o errexit
 
 CMD=$0
 
-# The covid-projections branch to open a PR against.
+# The covid-act-now-website branch to open a PR against.
 BRANCH="develop"
 
 # Checks command-line arguments, sets variables, etc.
@@ -30,7 +30,7 @@ prepare () {
   fi
 
   if [[ $COVID_DATA_MODEL_REF != "main" ]] ; then
-    echo "Not triggering covid-projections update-snapshot since this isn't a 'main' branch run."
+    echo "Not triggering covid-act-now-website update-snapshot since this isn't a 'main' branch run."
     exit 0
   fi
 
@@ -53,9 +53,9 @@ execute () {
   curl -H "Authorization: token $GITHUB_TOKEN" \
       --request POST \
       --data "{ \"ref\": \"${BRANCH}\", \"inputs\": { \"snapshot_id\": \"${SNAPSHOT_ID}\" } }" \
-      https://api.github.com/repos/act-now-coalition/covid-projections/actions/workflows/update-snapshot.yml/dispatches
+      https://api.github.com/repos/act-now-coalition/covid-act-now-website/actions/workflows/update-snapshot.yml/dispatches
 
-  echo "Snapshot update requested. Go to https://github.com/act-now-coalition/covid-projections/actions to monitor progress."
+  echo "Snapshot update requested. Go to https://github.com/act-now-coalition/covid-act-now-website/actions to monitor progress."
 }
 
 prepare "$@"


### PR DESCRIPTION
and other miscellaneous renamings.
 
The `deploy_api.yml` workflow stopped triggering the frontend workflow after the repo name change (see #notifications-daily-deploys in Slack)  