### PR TITLE
Reduce extra snapshot builds.

### DIFF
--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -5,9 +5,13 @@ name: Update combined datasets
 concurrency: gce-runner
 
 on:
-  schedule:
-    # Run job everyday at 5:00 am EST
-    - cron: '0 10 * * *'
+# 2023/01/17: We no longer have a run scheduled via github actions and instead rely on the prefect
+# scrapers to kick off a build after NYT updates each day.
+# https://github.com/covid-projections/can-scrapers/blob/643819f7a42d0ae227453b1de24a317a54c6cde8/services/prefect/flows/scheduled_nyt_and_parquet_updater.py#L37
+#
+#  schedule:
+#    # Run job everyday at 5:00 am EST
+#    - cron: '0 10 * * *'
   workflow_dispatch:
     inputs:
       trigger_api_build:


### PR DESCRIPTION
Compute Engine is our biggest GCP costs so trying to reduce unnecessary runs.  This will also reduce our S3 growth in AWS.  

If for any reason you are not comfortable with removing this, holler.  I don't feel super strongly.

![image](https://user-images.githubusercontent.com/206364/213037188-a289268f-90b4-4e2a-af4a-92119d731ad5.png)
