### PR TITLE
Fix off-by-one issue causing community levels to go blank

### DIFF
--- a/libs/metrics/community_levels.py
+++ b/libs/metrics/community_levels.py
@@ -92,7 +92,7 @@ def calculate_community_level_timeseries_and_latest(
 
     # Calculate CAN Community Levels from metrics. We allow canCommunityLevel to be based on
     # metrics that are up to MAX_METRIC_LOOKBACK_DAYS days old so ffill() them.
-    metrics_df = metrics_df.set_index([CommonFields.DATE]).ffill(limit=MAX_METRIC_LOOKBACK_DAYS - 2)
+    metrics_df = metrics_df.set_index([CommonFields.DATE]).ffill(limit=MAX_METRIC_LOOKBACK_DAYS - 1)
     can_community_level_series = metrics_df.apply(calculate_community_level_from_row, axis=1)
 
     # Extract CDC Community Levels from raw timeseries.

--- a/tests/libs/metrics/community_levels_test.py
+++ b/tests/libs/metrics/community_levels_test.py
@@ -41,7 +41,7 @@ def test_calc_community_levels(
         (1, CommunityLevel.MEDIUM),
         (13, CommunityLevel.MEDIUM),
         (14, CommunityLevel.MEDIUM),
-        (15, CommunityLevel.LOW),
+        (15, CommunityLevel.MEDIUM),
         (16, CommunityLevel.LOW),
         (100, CommunityLevel.LOW),
     ],


### PR DESCRIPTION
Forward-filling the metrics by `MAX_METRIC_LOOKBACK_DAYS - 2` (13 days) knocked the community-level-calculation logic out of sync with the top-level metric forward-filling. 

This caused a situation where the community-level logic determined that the hospital metrics were missing (and set the community level to `None`), but the metrics were still displayed/weren't filtered out by the rest of the API

Full snapshot building with these changes: https://github.com/act-now-coalition/covid-data-model/actions/runs/5084966505